### PR TITLE
Remove redundant preview image + fix broken link

### DIFF
--- a/index.md
+++ b/index.md
@@ -41,8 +41,6 @@ Our tools are configurable by design, support an exceptional range of features a
 
 If you want to modify our ANC Reference Application for your project or context, read our [configuration best practices](https://github.com/medic/medic.github.io/blob/master/resource-overviews/configuration-best-practices-overview.pdf) or learn how to [develope your own community health apps](https://github.com/medic/medic-docs/blob/master/configuration/developing-community-health-applications.md).
 
-[![ANC Overview](./images/preview-configuration-best-practices-overview.png)](./resource-overviews/configuration-best-practices-overview.pdf)
-
 ## OppiaMobile by Digital Campus
 
 OppiaMobile is an open source mobile learning platform specially designed  for delivering learning content, multimedia and quizzes in low-broadband settings. All the content and activities can be accessed and used even when no internet connection is available, and users can earn points and badges for completing activities, quizzes and watching videos. Visit Digital Campus's [website](https://digital-campus.org/oppiamobile/) to learn more about OppiaMobile's features. You can also read their platform [overview for developers](https://digital-campus.org/oppiamobile/developers/).
@@ -67,7 +65,7 @@ Have questions? Want to learn alongside a community of users? Join our [communit
 
 While our ANC Reference App can be used as is, most organizations and projects will want to configure and customize the app's tasks, care cuides, reports and even branding. These changes are not made at the Core Framework code level, but often still require technical skills and experience. To explore how we use forms to build the Tasks, Care Guides, and Reports that take health workers through care protocols and provide decision support for interactions with patients, read our [Configuration Best Practices Guide](./resource-overviews/configuration-best-practices-overview.pdf).
 
-[![Configuration Best Practices](./images/preview-configuration-best-practices-overview.png)
+[![ANC Confuguration](./images/preview-configuration-best-practices-overview.png)](./resource-overviews/configuration-best-practices-overview.pdf)
 
 To learn how to add your own logo, project name, and more to our Reference App, read our [App Branding Guide](https://github.com/medic/medic.github.io/blob/master/resource-overviews/app-branding-overview.pdf).
 


### PR DESCRIPTION
I had the Config Best Practices preview image in the doc twice. Also fixed the broken image link. 